### PR TITLE
feat(models): add img field to Article schema

### DIFF
--- a/models/Article.js
+++ b/models/Article.js
@@ -2,29 +2,39 @@ const mongoose = require('mongoose');
 
 const schema = new mongoose.Schema(
   {
+    img: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
     title: {
       type: String,
       required: true,
       trim: true,
       maxlength: 200,
     },
+
     author: {
       type: String,
       required: true,
       trim: true,
       maxlength: 100,
     },
+
     publishedAt: {
       type: Date,
       default: Date.now,
       immutable: true,
     },
+
     summary: {
       type: String,
       required: true,
       trim: true,
       maxlength: 500,
     },
+
     body: {
       type: String,
       required: true,


### PR DESCRIPTION
## Summary
feat: Add `img` field to Article Mongoose schema.

## Changes
- Added `img: { type: String, required: true, trim: true }` to Article schema.
- Kept existing fields (title, author, publishedAt, summary, body) and options the same.

## Motivation
Support article image uploads and ensure each article has an associated image for frontend lists/cards.
