### PR TITLE
refactor(api): add recalcCartTotals helper with clear calculation logic

### DIFF
--- a/src/app/api/utils/cartHelpers.js
+++ b/src/app/api/utils/cartHelpers.js
@@ -1,0 +1,27 @@
+export async function recalcCartTotals(cartDoc) {
+  await cartDoc.populate('items.product');
+
+  let totalPrice = 0;
+  let totalDiscount = 0;
+
+  for (const item of cartDoc.items || []) {
+    const p = item.product;
+    if (!p) continue;
+
+    const quantity = item.quantity || 0;
+
+    const basePrice = p.price ?? item.price ?? 0;
+
+    const finalPrice =
+      p.finalPrice ?? p.discountPrice ?? item.price ?? basePrice;
+
+    totalPrice += finalPrice * quantity;
+
+    totalDiscount += Math.max(basePrice - finalPrice, 0) * quantity;
+  }
+
+  cartDoc.totalPrice = totalPrice;
+  cartDoc.totalDiscount = totalDiscount;
+  cartDoc.finalPrice = totalPrice;
+  await cartDoc.save();
+}


### PR DESCRIPTION
## Summary
refactor: Implement `recalcCartTotals(cartDoc)` helper to recalculate cart totals with a clear, centralized algorithm.

## Changes
- Populates `items.product` and computes `totalPrice`, `totalDiscount`, and `finalPrice`.
- Uses `basePrice` (pre-discount) and `finalPrice` per item to calculate totals, taking `quantity` into account.
- Saves updated totals back to the cart document.

## Motivation
Centralize cart total calculation logic to avoid duplication across endpoints and ensure consistent price/discount computations.
