### PR TITLE
Feature/common components

### DIFF
--- a/src/components/common/ClientOnly.js
+++ b/src/components/common/ClientOnly.js
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ClientOnly({ children }) {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  if (!hasMounted) return null;
+
+  return children;
+}

--- a/src/components/common/SectionHeader.js
+++ b/src/components/common/SectionHeader.js
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import React from 'react';
+import Icon from './Icon';
+
+export default function SectionHeader({ title, subTitle, href, link, hasButton ,className }) {
+  return (
+    <div className={`flex items-end justify-between mb-5 md:mb-12 ${className}`}>
+      <div className="text-stone-800 dark:text-stone-400 flex flex-col justify-start">
+        <span className="section-title">{title}</span>
+
+        {subTitle && <span className="section-subtitle">{subTitle}</span>}
+      </div>
+
+      {link && (
+        <Link href={href} className="section-link">
+          <span className="inline-block">{link}</span>
+          <Icon name="chevLeft" className="size-4" />
+        </Link>
+      )}
+
+      {hasButton && (
+        <div className="flex gap-x-3 md:gap-x-[18px]">
+          <div className="swiper-button-prev-custom flex-center">
+            <Icon
+              name="chevRight"
+              className="w-5 h-5 md:w-[26px] md:h-[26px]"
+            />
+          </div>
+          <div className="swiper-button-next-custom flex-center">
+            <Icon name="chevLeft" className="w-5 h-5 md:w-[26px] md:h-[26px]" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
# ClientOnly :
## Summary
feat: Add `ClientOnly` component to render children only on the client after mount.

## Changes
- Uses `useEffect` to mark mount state to avoid rendering until the component has mounted.
- Returns `null` during SSR and initial render to prevent hydration mismatches.

## Motivation
Prevent SSR/CSR mismatches for components that require `window`, third-party libs, or client-only behavior.

# SectionHeader:
## Summary
refactor: Create a modular `SectionHeader` component that supports icons, optional links, and navigation buttons.

## Changes
- Accepts props: `title`, `subTitle`, `href`, `link`, `hasButton`, `className`.
- Uses an `Icon` component for chevrons and supports custom button layout for sliders (prev/next).
- Keeps styling via Tailwind utility classes.

## Motivation
Provide a single reusable header component for page sections to avoid duplicated markup and ensure consistent UI.

