### PR TITLE
Feature/utils

### DIFF
--- a/src/utils/authClient.js
+++ b/src/utils/authClient.js
@@ -1,0 +1,100 @@
+import { guestCartKey } from '@/constants/auth';
+
+export const getGuestCart = () => {
+  try {
+    if (typeof window === 'undefined') return null;
+    const raw = localStorage.getItem(guestCartKey);
+    return raw ? JSON.parse(raw) : null;
+  } catch (e) {
+    console.error('Failed to get guest cart:', e);
+    return null;
+  }
+};
+
+export const clearGuestCart = () => {
+  try {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(guestCartKey);
+  } catch (e) {
+    console.error('Failed to clear guest cart:', e);
+  }
+};
+
+const getGuestId = () => {
+  try {
+    if (typeof window === 'undefined') return null;
+    return localStorage.getItem('guestId') || null;
+  } catch (e) {
+    return null;
+  }
+};
+
+const jsonOrText = async (res) => {
+  try {
+    const text = await res.text();
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      return text;
+    }
+  } catch (e) {
+    return null;
+  }
+};
+
+export const signin = async ({ email, password }) => {
+  const guestCart = getGuestCart();
+  const guestId = getGuestId();
+
+  const res = await fetch('/api/auth/signin', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(guestId ? { 'x-guest-id': guestId } : {}),
+    },
+    body: JSON.stringify({ email, password, guestCart }),
+    credentials: 'include',
+  });
+
+  if (res.ok) {
+    const data = await res.json().catch(() => null);
+    clearGuestCart();
+    return data;
+  }
+
+  const payload = await jsonOrText(res);
+  if (payload && typeof payload === 'object') {
+    payload.status = res.status;
+    throw payload;
+  }
+  throw { status: res.status, message: payload || 'Signin failed' };
+};
+
+export const signup = async (payload) => {
+  const guestCart = getGuestCart();
+  const guestId = getGuestId();
+
+  const res = await fetch('/api/auth/signup', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(guestId ? { 'x-guest-id': guestId } : {}),
+    },
+    body: JSON.stringify({ ...payload, guestCart }),
+    credentials: 'include',
+  });
+
+  if (res.ok) {
+    const data = await res.json().catch(() => null);
+    clearGuestCart();
+    return data;
+  }
+
+  const body = await jsonOrText(res);
+  if (body && typeof body === 'object') {
+    body.status = res.status;
+    throw body;
+  }
+
+  throw { status: res.status, message: body || 'Signup failed' };
+};

--- a/src/utils/fieldValidator.js
+++ b/src/utils/fieldValidator.js
@@ -1,0 +1,83 @@
+
+import {
+  validateEmail,
+  validateUsername,
+  validateName,
+  validatePhone,
+  validatePassword,
+  stringRequired,
+} from '@/utils/validators';
+
+const rules = {
+  firstName: [
+    { fn: (v) => stringRequired(v), msg: 'نام الزامی است' },
+    { fn: (v) => validateName(v), msg: 'نباید بیشتر از ۵۰ کاراکتر باشد' },
+  ],
+  lastName: [
+    { fn: (v) => stringRequired(v), msg: 'نام خانوادگی الزامی است' },
+    { fn: (v) => validateName(v), msg: 'نباید بیشتر از ۵۰ کاراکتر باشد' },
+  ],
+  username: [
+    { fn: (v) => stringRequired(v), msg: 'نام کاربری الزامی است' },
+    {
+      fn: (v) => validateUsername(v),
+      msg: 'باید بین ۳-۳۰ حرف،  و با حرف شروع شود)',
+    },
+  ],
+  email: [
+    { fn: (v) => stringRequired(v), msg: 'ایمیل الزامی است' },
+    { fn: (v) => validateEmail(v), msg: 'ایمیل نامعتبر است' },
+  ],
+  phone: [
+    {
+      fn: (v) => !v || validatePhone(v),
+      msg: 'شماره موبایل نامعتبر (مثال: 09123456789)',
+    },
+  ],
+  password: [
+    { fn: (v) => stringRequired(v), msg: 'رمز عبور الزامی است' },
+    {
+      fn: (v) => validatePassword(v),
+      msg: 'باید حداقل ۸ کاراکتر شامل حرف بزرگ، کوچک، عدد و نماد باشد',
+    },
+  ],
+  loginEmail: [
+    { fn: (v) => stringRequired(v), msg: 'ایمیل الزامی است' },
+    { fn: (v) => validateEmail(v), msg: 'ایمیل نامعتبر است' },
+  ],
+  loginPassword: [
+    { fn: (v) => stringRequired(v), msg: 'رمز عبور الزامی است' },
+    {
+      fn: (v) => v && v.length >= 8,
+      msg: 'رمز عبور باید حداقل ۸ کاراکتر باشد',
+    },
+  ],
+};
+
+export function validateField(field, val) {
+  const rs = rules[field];
+  if (!rs) return '';
+  for (const r of rs) {
+    try {
+      if (!r.fn(val)) return r.msg;
+    } catch (e) {
+      return r.msg;
+    }
+  }
+  return '';
+}
+
+export function validateAll(obj = {}) {
+  const errors = {};
+  for (const k of Object.keys(obj)) {
+    const e = validateField(k, obj[k]);
+    if (e) errors[k] = e;
+  }
+  return errors;
+}
+
+export function isValid(obj = {}) {
+  return Object.keys(validateAll(obj)).length === 0;
+}
+
+export default validateField;

--- a/src/utils/guestCart.js
+++ b/src/utils/guestCart.js
@@ -1,0 +1,25 @@
+import { guestCartKey } from '@/constants/auth';
+
+export const getGuestCart = () => {
+  try {
+    if (typeof window === 'undefined') return null;
+    const raw = localStorage.getItem(guestCartKey);
+    return raw ? JSON.parse(raw) : null;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const saveGuestCart = (cart) => {
+  try {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(guestCartKey, JSON.stringify(cart));
+  } catch (e) {}
+};
+
+export const clearGuestCart = () => {
+  try {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(guestCartKey);
+  } catch (e) {}
+};

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -1,0 +1,9 @@
+export function slugify(text) {
+  return text
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-') // space  → "-"
+    .replace(/[^\w\u0600-\u06FF\-]+/g, '')
+    .replace(/\-\-+/g, '-'); // "--" → "-"
+}


### PR DESCRIPTION
# authClient :
## Summary
refactor: Client-side auth helpers (`signin`, `signup`) that include guest cart handling and localStorage utilities.

## Changes
- Uses `guestCartKey` from constants to read/clear guest cart from localStorage.
- Added helpers `getGuestCart`, `clearGuestCart`, `getGuestId`.
- `signin` and `signup` POST to `/api/auth/signin` and `/api/auth/signup` respectively, sending `guestCart` in the body and `x-guest-id` header when available.
- Clears local guest cart on success and throws structured error objects on failure.

## Motivation
Preserve client-side guest cart state and coordinate it with server-side merging during auth transitions to avoid data loss and inconsistent behavior.


# fieldValidators : 
## Summary
refactor: Centralize client-side field validation rules and helper functions with Persian error messages.

## Changes
- Defined validation `rules` for `firstName`, `lastName`, `username`, `email`, `phone`, `password`, `loginEmail`, and `loginPassword`.
- Each rule contains a `fn` (predicate) and `msg` (Persian error message).
- Exported `validateField`, `validateAll`, `isValid` and default `validateField`.

## Motivation
Provide a single source of truth for form validation and error messages so front-end forms are consistent and easier to maintain.


# GuestCarts : 
## Summary
chore: Add simple helpers to read, save, and clear guest cart data in localStorage.

## Changes
- Implemented `getGuestCart`, `saveGuestCart`, and `clearGuestCart` using `guestCartKey`.
- Guards against server-side execution (`typeof window` checks).

## Motivation
Encapsulate localStorage logic for guest cart handling and reuse it in auth and cart-related client code.

# Slugify :
## Summary
feat: Add `slugify(text)` utility to generate SEO-friendly slugs with Persian and English support.

## Changes
- Converts text to lowercase, trims, replaces spaces with `-`, removes invalid characters while preserving Persian letters (`\u0600-\u06FF`), and collapses repeated dashes.
- Returns a clean slug suitable for URLs and SEO.

## Motivation
Generate readable and SEO-friendly slugs for articles and products in both Persian and English content.
