### PR TITLE
feat(templates/products): add Products grid with SectionHeader and Product cards

### DIFF
--- a/src/components/templates/products/Products.js
+++ b/src/components/templates/products/Products.js
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import { getProducts } from '@/libs/productApi';
+import { useQuery } from '@tanstack/react-query';
+import SectionHeader from '@/components/common/SectionHeader';
+import Product from '@/components/modules/product/Product';
+
+export default function Products() {
+  const { data } = useQuery({
+    queryKey: ['products'],
+    queryFn: getProducts,
+  });
+
+  const products = Array.isArray(data) ? data : data?.data || [];
+
+  return (
+    <section className="products pt-8 md:pt-24">
+      <div className="container">
+        <SectionHeader
+          className="lg:pt-48"
+          title="جدیدترین محصولات"
+          subTitle="دانه‌هایی آماده برای یک فنجان دلنشین"
+          link="مشاهده همه"
+          href="/shop"
+        />
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3.5 md:gap-5">
+          {products.slice(0, 8).map((product) => (
+            <Product
+              key={product._id}
+              id={product._id}
+              img={product.img}
+              name={product.name}
+              shortDescription={product.shortDescription}
+              isSpecial={product.isSpecial}
+              isNew={product.isNew}
+              discount={product.discount}
+              score={product.score}
+              weight={product.weight}
+              price={product.price}
+              finalPrice={product.finalPrice}
+              stock={product.stock}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION

## Summary
feat: Add `Products` section that fetches products and renders Product cards in a responsive grid.

## Changes
- Uses `getProducts` with React Query and normalizes returned payloads.
- Renders `SectionHeader` and up to 8 `Product` components per page.
- Responsive grid layout for multiple breakpoints.

## Motivation
Provide the homepage with a preview of newest products to encourage browsing and purchases.
