### PR TITLE
feat(templates/services): add Services section rendering reusable Service items

### DIFF
--- a/src/components/templates/services/Services.js
+++ b/src/components/templates/services/Services.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { services } from '@/constants/services';
+import Service from '@/components/modules/service/Service';
+
+export default function Services() {
+  return (
+    <section className="services mb-12 lg:mb-36">
+      <div className="container">
+        <div className="flex items-center justify-between gap-y-11 flex-wrap *:w-1/2 lg:*:w-auto text-stone-800 dark:text-white">
+          {services.map((service) => (
+            <Service
+              key={service.id}
+              title={service.title}
+              desc={service.desc}
+              icon={service.icon}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
feat: Add `Services` section that renders a list of service items from constants.

## Changes
- Imports `services` from constants and maps them to reusable `Service` components.
- Layout supports wrapping and responsive spacing for different viewports.

## Motivation
Show service/features highlights on the homepage in a consistent and maintainable way by using a constants-driven approach.
